### PR TITLE
Pinned importlib-metadata to 1.7.0 for python35

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,6 @@
 #
 #    make upgrade
 #
-django==2.2.12            # via -c requirements/constraints.txt, -r requirements/base.in
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in
 pytz==2020.1              # via django
 sqlparse==0.3.1           # via django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,3 +12,6 @@
 
 # Stay on an LTS release
 django<2.3              # Web application framework
+
+# importlib-metadata>1.7.0 is causing conflicts in running make upgrade on python35
+importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,62 +6,61 @@
 #
 appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
-attrs==19.3.0             # via -r requirements/quality.txt, pytest
-certifi==2020.4.5.1       # via -r requirements/travis.txt, requests
+attrs==20.2.0             # via -r requirements/quality.txt, pytest
+certifi==2020.6.20        # via -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/travis.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
-codecov==2.1.3            # via -r requirements/travis.txt
-coverage==5.1             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
-diff-cover==2.6.1         # via -r requirements/dev.in
-distlib==0.3.0            # via -r requirements/travis.txt, virtualenv
-django==2.2.12            # via -c requirements/constraints.txt, -r requirements/quality.txt, edx-i18n-tools
+codecov==2.1.9            # via -r requirements/travis.txt
+coverage==5.3             # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, pytest-cov
+diff-cover==4.0.1         # via -r requirements/dev.in
+distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/quality.txt, edx-i18n-tools
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
-edx-lint==1.4.1           # via -r requirements/quality.txt
+edx-lint==1.5.2           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
-idna==2.9                 # via -r requirements/travis.txt, requests
-importlib-metadata==1.6.0  # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==1.5.0  # via -r requirements/travis.txt, virtualenv
+idna==2.10                # via -r requirements/travis.txt, requests
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, inflect, path, pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 inflect==3.0.2            # via jinja2-pluralize
+iniconfig==1.0.1          # via -r requirements/quality.txt, pytest
 isort==4.3.21             # via -r requirements/quality.txt, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via diff-cover, jinja2-pluralize
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
-more-itertools==8.3.0     # via -r requirements/quality.txt, pytest
 packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
-path.py==12.4.0           # via edx-i18n-tools
+path.py==12.5.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
-pip-tools==5.1.2          # via -r requirements/pip-tools.txt
+pip-tools==5.3.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
-py==1.8.1                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+py==1.9.0                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
-pydocstyle==5.0.2         # via -r requirements/quality.txt
-pygments==2.6.1           # via diff-cover
+pydocstyle==5.1.1         # via -r requirements/quality.txt
+pygments==2.7.1           # via diff-cover
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
-pylint==2.4.2             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
-pytest-cov==2.8.1         # via -r requirements/quality.txt
-pytest-django==3.9.0      # via -r requirements/quality.txt
-pytest==5.4.2             # via -r requirements/quality.txt, pytest-cov, pytest-django
+pytest-cov==2.10.1        # via -r requirements/quality.txt
+pytest-django==3.10.0     # via -r requirements/quality.txt
+pytest==6.1.0             # via -r requirements/quality.txt, pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/quality.txt, django
 pyyaml==5.3.1             # via edx-i18n-tools
-requests==2.23.0          # via -r requirements/travis.txt, codecov
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, diff-cover, edx-i18n-tools, edx-lint, packaging, pathlib2, pip-tools, tox, virtualenv
+requests==2.24.0          # via -r requirements/travis.txt, codecov
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-i18n-tools, edx-lint, packaging, pathlib2, pip-tools, tox, virtualenv
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 sqlparse==0.3.1           # via -r requirements/quality.txt, django
-toml==0.10.1              # via -r requirements/travis.txt, tox
-tox-battery==0.6.0        # via -r requirements/travis.txt
-tox==3.15.1               # via -r requirements/travis.txt, tox-battery
+toml==0.10.1              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+tox-battery==0.6.1        # via -r requirements/travis.txt
+tox==3.20.0               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
-urllib3==1.25.9           # via -r requirements/travis.txt, requests
-virtualenv==20.0.21       # via -r requirements/travis.txt, tox
-wcwidth==0.1.9            # via -r requirements/quality.txt, pytest
+urllib3==1.25.10          # via -r requirements/travis.txt, requests
+virtualenv==20.0.31       # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,39 +5,39 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-attrs==19.3.0             # via -r requirements/test.txt, pytest
+attrs==20.2.0             # via -r requirements/test.txt, pytest
 babel==2.8.0              # via sphinx
-bleach==3.1.5             # via readme-renderer
-certifi==2020.4.5.1       # via requests
+bleach==3.2.1             # via readme-renderer
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via doc8, requests
-coverage==5.1             # via -r requirements/test.txt, pytest-cov
-django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt
-doc8==0.8.0               # via -r requirements/doc.in
+coverage==5.3             # via -r requirements/test.txt, pytest-cov
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt
+doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-idna==2.9                 # via requests
+idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
+iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
-more-itertools==8.3.0     # via -r requirements/test.txt, pytest
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
-pbr==5.4.5                # via stevedore
+pbr==5.5.0                # via stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-py==1.8.1                 # via -r requirements/test.txt, pytest
-pygments==2.6.1           # via readme-renderer, sphinx
+py==1.9.0                 # via -r requirements/test.txt, pytest
+pygments==2.7.1           # via doc8, readme-renderer, sphinx
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.8.1         # via -r requirements/test.txt
-pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest-cov==2.10.1        # via -r requirements/test.txt
+pytest-django==3.10.0     # via -r requirements/test.txt
+pytest==6.1.0             # via -r requirements/test.txt, pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/test.txt, babel, django
 readme-renderer==26.0     # via -r requirements/doc.in
-requests==2.23.0          # via sphinx
-restructuredtext-lint==1.3.0  # via doc8
+requests==2.24.0          # via sphinx
+restructuredtext-lint==1.3.1  # via doc8
 six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, packaging, pathlib2, readme-renderer, stevedore
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.0.3             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.2.1             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -46,8 +46,8 @@ sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via doc8
-urllib3==1.25.9           # via requests
-wcwidth==0.1.9            # via -r requirements/test.txt, pytest
+toml==0.10.1              # via -r requirements/test.txt, pytest
+urllib3==1.25.10          # via requests
 webencodings==0.5.1       # via bleach
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata
 

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.1.2          # via -r requirements/pip-tools.in
+pip-tools==5.3.1          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -5,36 +5,36 @@
 #    make upgrade
 #
 astroid==2.3.3            # via pylint, pylint-celery
-attrs==19.3.0             # via -r requirements/test.txt, pytest
+attrs==20.2.0             # via -r requirements/test.txt, pytest
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
-coverage==5.1             # via -r requirements/test.txt, pytest-cov
-django==2.2.12            # via -c requirements/constraints.txt, -r requirements/test.txt
-edx-lint==1.4.1           # via -r requirements/quality.in
-importlib-metadata==1.6.0  # via -r requirements/test.txt, pluggy, pytest
+coverage==5.3             # via -r requirements/test.txt, pytest-cov
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/test.txt
+edx-lint==1.5.2           # via -r requirements/quality.in
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
+iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
-more-itertools==8.3.0     # via -r requirements/test.txt, pytest
 packaging==20.4           # via -r requirements/test.txt, pytest
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
-py==1.8.1                 # via -r requirements/test.txt, pytest
+py==1.9.0                 # via -r requirements/test.txt, pytest
 pycodestyle==2.6.0        # via -r requirements/quality.in
-pydocstyle==5.0.2         # via -r requirements/quality.in
+pydocstyle==5.1.1         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-cov==2.8.1         # via -r requirements/test.txt
-pytest-django==3.9.0      # via -r requirements/test.txt
-pytest==5.4.2             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest-cov==2.10.1        # via -r requirements/test.txt
+pytest-django==3.10.0     # via -r requirements/test.txt
+pytest==6.1.0             # via -r requirements/test.txt, pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/test.txt, django
 six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, packaging, pathlib2
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via -r requirements/test.txt, django
+toml==0.10.1              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via astroid
-wcwidth==0.1.9            # via -r requirements/test.txt, pytest
 wrapt==1.11.2             # via astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,20 +4,20 @@
 #
 #    make upgrade
 #
-attrs==19.3.0             # via pytest
-coverage==5.1             # via pytest-cov
-importlib-metadata==1.6.0  # via pluggy, pytest
-more-itertools==8.3.0     # via pytest
+attrs==20.2.0             # via pytest
+coverage==5.3             # via pytest-cov
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
+iniconfig==1.0.1          # via pytest
 packaging==20.4           # via pytest
 pathlib2==2.3.5           # via pytest
 pluggy==0.13.1            # via pytest
-py==1.8.1                 # via pytest
+py==1.9.0                 # via pytest
 pyparsing==2.4.7          # via packaging
-pytest-cov==2.8.1         # via -r requirements/test.in
-pytest-django==3.9.0      # via -r requirements/test.in
-pytest==5.4.2             # via pytest-cov, pytest-django
+pytest-cov==2.10.1        # via -r requirements/test.in
+pytest-django==3.10.0     # via -r requirements/test.in
+pytest==6.1.0             # via pytest-cov, pytest-django
 pytz==2020.1              # via -r requirements/base.txt, django
 six==1.15.0               # via packaging, pathlib2
 sqlparse==0.3.1           # via -r requirements/base.txt, django
-wcwidth==0.1.9            # via pytest
+toml==0.10.1              # via pytest
 zipp==1.2.0               # via importlib-metadata

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,25 +4,25 @@
 #
 #    make upgrade
 #
-appdirs==1.4.3            # via virtualenv
-certifi==2020.4.5.1       # via requests
+appdirs==1.4.4            # via virtualenv
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-codecov==2.0.22           # via -r requirements/travis.in
-coverage==5.1             # via codecov
-distlib==0.3.0            # via virtualenv
+codecov==2.1.9            # via -r requirements/travis.in
+coverage==5.3             # via codecov
+distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
-idna==2.9                 # via requests
-importlib-metadata==1.6.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==1.5.0  # via virtualenv
-packaging==20.3           # via tox
+idna==2.10                # via requests
+importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
+packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
-py==1.8.1                 # via tox
+py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
-requests==2.23.0          # via codecov
-six==1.14.0               # via packaging, tox, virtualenv
-toml==0.10.0              # via tox
-tox-battery==0.5.2        # via -r requirements/travis.in
-tox==3.15.0               # via -r requirements/travis.in, tox-battery
-urllib3==1.25.9           # via requests
-virtualenv==20.0.19       # via tox
+requests==2.24.0          # via codecov
+six==1.15.0               # via packaging, tox, virtualenv
+toml==0.10.1              # via tox
+tox-battery==0.6.1        # via -r requirements/travis.in
+tox==3.20.0               # via -r requirements/travis.in, tox-battery
+urllib3==1.25.10          # via requests
+virtualenv==20.0.31       # via tox
 zipp==1.2.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
- Pinned `importlib-metadata==1.7.0` as `version>1.7.0` is causing conflicts for python35 in running `make upgrade`.